### PR TITLE
Add CSV irradiance upload option to POA app

### DIFF
--- a/pv_poa_app.py
+++ b/pv_poa_app.py
@@ -50,6 +50,13 @@ def compute_daily_energy_kwh(series: pd.Series) -> pd.Series:
     return daily
 
 
+@st.cache_data(show_spinner=False)
+def dataframe_to_csv_bytes(df: pd.DataFrame) -> bytes:
+    """Serialize a dataframe (with index) to UTF-8 encoded CSV bytes for download."""
+
+    return df.to_csv(index=True).encode("utf-8")
+
+
 def process_csv_irradiance(
     raw_df: pd.DataFrame,
     timestamp_col: str,
@@ -385,6 +392,13 @@ with st.expander("Time series — POA components", expanded=True):
         margin=dict(l=40, r=20, t=40, b=40),
     )
     st.plotly_chart(fig, use_container_width=True)
+    st.download_button(
+        "Download POA time series (CSV)",
+        data=dataframe_to_csv_bytes(df),
+        file_name="poa_timeseries.csv",
+        mime="text/csv",
+        use_container_width=True,
+    )
 
 # Daily totals bar
 with st.expander("Daily POA energy (kWh/m²/day)", expanded=False):
@@ -398,9 +412,24 @@ with st.expander("Daily POA energy (kWh/m²/day)", expanded=False):
         margin=dict(l=40, r=20, t=40, b=40),
     )
     st.plotly_chart(bar, use_container_width=True)
+    st.download_button(
+        "Download daily POA totals (CSV)",
+        data=dataframe_to_csv_bytes(poa_summary),
+        file_name="poa_daily_totals.csv",
+        mime="text/csv",
+        use_container_width=True,
+    )
 
 # Monthly totals table
 with st.expander("Monthly totals (kWh/m² per month)", expanded=False):
-    st.dataframe(monthly_summary.rename(columns={"POA_kWh_per_m2": "POA kWh/m²"}))
+    monthly_display = monthly_summary.rename(columns={"POA_kWh_per_m2": "POA kWh/m²"})
+    st.dataframe(monthly_display)
+    st.download_button(
+        "Download monthly POA totals (CSV)",
+        data=dataframe_to_csv_bytes(monthly_summary),
+        file_name="poa_monthly_totals.csv",
+        mime="text/csv",
+        use_container_width=True,
+    )
 
 st.caption("Model: pvlib Ineichen clear-sky or user-provided CSV irradiance (GHI/DNI/DHI). CSV timestamps are shifted to the selected timezone and present year.")

--- a/pv_poa_app.py
+++ b/pv_poa_app.py
@@ -3,12 +3,105 @@
 # Streamlit app to estimate plane-of-array (POA) irradiance using pvlib clearsky models
 # Run with: streamlit run pv_poa_app.py
 
+from typing import Optional
+
 import pandas as pd
 import numpy as np
 import streamlit as st
 import plotly.graph_objects as go
 from pvlib.location import Location
 import pvlib
+
+NS_PER_HOUR = 3_600_000_000_000
+
+
+def _safe_replace_year(ts: pd.Timestamp, target_year: int) -> Optional[pd.Timestamp]:
+    """Return *ts* with the year replaced, handling leap years gracefully."""
+
+    try:
+        return ts.replace(year=target_year)
+    except ValueError:
+        if ts.month == 2 and ts.day == 29:
+            return ts.replace(year=target_year, month=2, day=28)
+    return None
+
+
+def compute_daily_energy_kwh(series: pd.Series) -> pd.Series:
+    """Integrate a W/m² time-series to daily kWh/m² using forward differences."""
+
+    if series.empty:
+        return pd.Series(dtype=float)
+
+    idx = series.index
+    values = series.to_numpy(dtype=float)
+
+    if len(values) == 1:
+        delta_hours = np.zeros_like(values)
+    else:
+        diffs = np.diff(idx.asi8) / NS_PER_HOUR
+        positive_diffs = diffs[diffs > 0]
+        fallback = float(np.median(positive_diffs)) if positive_diffs.size else 1.0
+        diffs = np.where(diffs > 0, diffs, fallback)
+        delta_hours = np.append(diffs, fallback)
+
+    energy = values * delta_hours / 1000.0
+    daily = pd.Series(energy, index=idx).resample("D").sum(min_count=1)
+    daily.index.name = "date"
+    return daily
+
+
+def process_csv_irradiance(
+    raw_df: pd.DataFrame,
+    timestamp_col: str,
+    ghi_col: str,
+    dni_col: str,
+    dhi_col: str,
+    tz: str,
+    target_year: int,
+    window_start: pd.Timestamp,
+    window_end: pd.Timestamp,
+) -> pd.DataFrame:
+    """Return a cleaned, timezone-aware irradiance dataframe sourced from CSV."""
+
+    working = raw_df[[timestamp_col, ghi_col, dni_col, dhi_col]].copy()
+    working.columns = ["timestamp", "GHI", "DNI", "DHI"]
+
+    working["timestamp"] = pd.to_datetime(working["timestamp"], errors="coerce")
+    working = working.dropna(subset=["timestamp"])
+
+    for col in ["GHI", "DNI", "DHI"]:
+        working[col] = pd.to_numeric(working[col], errors="coerce")
+    working = working.dropna(subset=["GHI", "DNI", "DHI"])
+
+    if working.empty:
+        return pd.DataFrame(columns=["GHI", "DNI", "DHI"])
+
+    timestamps = pd.DatetimeIndex(working.pop("timestamp"))
+
+    if timestamps.tz is None:
+        localized = timestamps.tz_localize(tz, nonexistent="NaT", ambiguous="NaT")
+    else:
+        localized = timestamps.tz_convert(tz)
+
+    valid_mask = ~localized.isna()
+    working = working.loc[valid_mask]
+    localized = localized[valid_mask]
+
+    aligned = localized.map(lambda ts: _safe_replace_year(ts, target_year))
+    aligned = pd.Index(aligned)
+    aligned_mask = aligned.notna()
+    working = working.loc[aligned_mask]
+    aligned = aligned[aligned_mask]
+
+    if working.empty:
+        return pd.DataFrame(columns=["GHI", "DNI", "DHI"])
+
+    working.index = pd.DatetimeIndex(aligned).tz_convert(tz)
+    working = working.sort_index()
+    working = working.groupby(level=0).mean()
+
+    window = working.loc[(working.index >= window_start) & (working.index <= window_end)]
+    return window
 
 def build_azimuth_compass(angle_deg: float) -> go.Figure:
     """Return a compass-style polar chart highlighting the chosen azimuth."""
@@ -90,6 +183,9 @@ st.set_page_config(page_title="PV POA Irradiance (pvlib)", layout="wide")
 
 st.title("☀️ PV Plane-of-Array Irradiance — pvlib (clear-sky)")
 
+csv_df: Optional[pd.DataFrame] = None
+timestamp_col = ghi_col = dni_col = dhi_col = None
+
 with st.sidebar:
     st.header("Location & Time")
     lat = st.number_input("Latitude (°)", value=41.4836, format="%.4f")  # default Lisbon
@@ -118,42 +214,114 @@ with st.sidebar:
         360,
         200,
     )
-    
+
     st.subheader("Orientation preview")
     st.plotly_chart(build_azimuth_compass(azimuth), width="stretch")
-    
+
     albedo = st.slider("Ground albedo", 0.0, 0.9, 0.6, step=0.01)
 
     st.header("Sampling")
     freq_label = st.selectbox("Time step", ["15 min", "30 min", "1h"], index=2)
     freq = {"15 min": "15min", "30 min": "30min", "1h": "1h"}[freq_label]
 
+    st.header("Irradiance source")
+    source_label = st.radio(
+        "Use clear-sky or upload measured data?",
+        (
+            "Clear-sky (pvlib Ineichen)",
+            "Upload CSV (map to GHI/DNI/DHI)",
+        ),
+    )
+
+    if source_label == "Upload CSV (map to GHI/DNI/DHI)":
+        uploaded_file = st.file_uploader("CSV with irradiance columns", type=["csv"])
+        if uploaded_file is not None:
+            csv_df = pd.read_csv(uploaded_file)
+            st.caption(f"Loaded {csv_df.shape[0]} rows × {csv_df.shape[1]} columns")
+            if not csv_df.empty:
+                timestamp_col = st.selectbox(
+                    "Timestamp column",
+                    options=csv_df.columns.tolist(),
+                    key="timestamp_column_select",
+                )
+                remaining = [c for c in csv_df.columns if c != timestamp_col]
+                if len(remaining) < 3:
+                    st.warning("Pick a CSV with columns for GHI, DNI, and DHI.")
+                else:
+                    ghi_col = st.selectbox(
+                        "Column → GHI",
+                        options=remaining,
+                        key="ghi_column_select",
+                    )
+                    remaining_dni = [c for c in remaining if c != ghi_col]
+                    dni_col = st.selectbox(
+                        "Column → DNI",
+                        options=remaining_dni,
+                        key="dni_column_select",
+                    )
+                    remaining_dhi = [c for c in remaining_dni if c != dni_col]
+                    if remaining_dhi:
+                        dhi_col = st.selectbox(
+                            "Column → DHI",
+                            options=remaining_dhi,
+                            key="dhi_column_select",
+                        )
+                    else:
+                        st.warning("Select distinct columns for each irradiance component.")
+            else:
+                st.warning("Uploaded file is empty.")
+
 st.markdown(
     """
-This tool computes **clear-sky** irradiance using pvlib's Ineichen model and transposes it to the **plane-of-array (POA)** for your
-specified tilt and azimuth. It's a great first step to size PV and understand seasonal/diurnal patterns. Later, you can switch to
-measured or TMY weather to include clouds and real conditions.
+This tool computes plane-of-array (POA) irradiance using either pvlib's **clear-sky Ineichen model** or **user-supplied CSV irradiance data**. Map your CSV columns to GHI/DNI/DHI to evaluate measured or TMY datasets, or stick with the clear-sky baseline for quick feasibility scans.
 """)
 
 
 
 
-# Build time index
+target_year = pd.Timestamp.today(tz=tz).year
 start = pd.Timestamp.combine(pd.to_datetime(date_start), pd.Timestamp.min.time()).tz_localize(tz)
 end = pd.Timestamp.combine(pd.to_datetime(date_end), pd.Timestamp.max.time()).tz_localize(tz)
-
-times = pd.date_range(start=start, end=end, freq=freq, tz=tz)
 
 # Location object
 site = Location(latitude=lat, longitude=lon, tz=tz, altitude=elevation, name="Site")
 
+if source_label == "Clear-sky (pvlib Ineichen)":
+    times = pd.date_range(start=start, end=end, freq=freq, tz=tz)
+    clearsky = site.get_clearsky(times, model="ineichen").rename(columns=str.upper)
+    irradiance_components = clearsky[["GHI", "DNI", "DHI"]]
+else:
+    if csv_df is None or not all([timestamp_col, ghi_col, dni_col, dhi_col]):
+        st.info("Upload a CSV and map each irradiance component to continue.")
+        st.stop()
+
+    csv_processed = process_csv_irradiance(
+        csv_df,
+        timestamp_col,
+        ghi_col,
+        dni_col,
+        dhi_col,
+        tz,
+        target_year,
+        start,
+        end,
+    )
+
+    if csv_processed.empty:
+        st.error("No rows remain after cleaning. Adjust the date range, timezone, or CSV mappings.")
+        st.stop()
+
+    times = csv_processed.index
+    irradiance_components = csv_processed
+
+if source_label != "Clear-sky (pvlib Ineichen)":
+    st.success(f"Loaded {irradiance_components.shape[0]} timestamps from the CSV after cleaning and year alignment.")
+    with st.expander("CSV irradiance preview", expanded=False):
+        st.dataframe(irradiance_components.head(100))
+
 # Solar position
 solpos = site.get_solarposition(times)
 
-# Clear-sky (Ineichen)
-clearsky = site.get_clearsky(times, model="ineichen")  # returns ghi, dni, dhi
-# Standardize column names to upper-case for downstream access
-clearsky = clearsky.rename(columns=str.upper)
 
 # Airmass for temp model (optional - here just to demonstrate pipeline)
 pressure = pvlib.atmosphere.alt2pres(elevation)
@@ -164,40 +332,43 @@ am_abs = pvlib.atmosphere.get_absolute_airmass(airmass, pressure)
 total_irr = pvlib.irradiance.get_total_irradiance(
     surface_tilt=tilt,
     surface_azimuth=azimuth,
-    dni=clearsky["DNI"],
-    ghi=clearsky["GHI"],
-    dhi=clearsky["DHI"],
+    dni=irradiance_components["DNI"],
+    ghi=irradiance_components["GHI"],
+    dhi=irradiance_components["DHI"],
     solar_zenith=solpos["apparent_zenith"],
     solar_azimuth=solpos["azimuth"],
     albedo=albedo,
 )
 
+
 # Combine results
 df = pd.DataFrame({
-    "GHI": clearsky["GHI"],
-    "DNI": clearsky["DNI"],
-    "DHI": clearsky["DHI"],
+    "GHI": irradiance_components["GHI"],
+    "DNI": irradiance_components["DNI"],
+    "DHI": irradiance_components["DHI"],
     "POA_Global": total_irr["poa_global"],
     "POA_Beam": total_irr["poa_direct"],
     "POA_Diffuse": total_irr["poa_sky_diffuse"],
     "POA_GroundReflected": total_irr["poa_ground_diffuse"],
 })
 
+
 # Daily totals in kWh/m^2/day for POA
-poa_wh = df["POA_Global"].resample("D").sum(min_count=1) * (pd.to_timedelta(freq).total_seconds() / 3600.0) / 1000.0
+daily_poa_kwh = compute_daily_energy_kwh(df["POA_Global"])
 poa_summary = pd.DataFrame({
-    "POA_kWh_per_m2": poa_wh,
+    "POA_kWh_per_m2": daily_poa_kwh,
 })
 monthly_summary = poa_summary.resample("MS").sum()
 
 # KPI cards
 col1, col2, col3 = st.columns(3)
-total_kwh_m2 = poa_wh.sum()
+total_kwh_m2 = daily_poa_kwh.sum()
 peak_poa = df["POA_Global"].max()
-day_with_max = poa_wh.idxmax() if not poa_wh.empty else None
+day_with_max = daily_poa_kwh.idxmax() if not daily_poa_kwh.empty else None
 col1.metric("Total POA (kWh/m²)", f"{total_kwh_m2:.1f}")
 col2.metric("Peak POA (W/m²)", f"{peak_poa:.0f}")
 col3.metric("Best day", f"{day_with_max.date() if day_with_max is not None else '—'}")
+
 
 # Plot time series (POA components)
 with st.expander("Time series — POA components", expanded=True):
@@ -218,7 +389,7 @@ with st.expander("Time series — POA components", expanded=True):
 # Daily totals bar
 with st.expander("Daily POA energy (kWh/m²/day)", expanded=False):
     bar = go.Figure()
-    bar.add_trace(go.Bar(x=poa_wh.index, y=poa_wh.values, name="Daily POA kWh/m²"))
+    bar.add_trace(go.Bar(x=daily_poa_kwh.index, y=daily_poa_kwh.values, name="Daily POA kWh/m²"))
     bar.update_layout(
         xaxis_title="Day",
         yaxis_title="kWh/m²/day",
@@ -232,4 +403,4 @@ with st.expander("Daily POA energy (kWh/m²/day)", expanded=False):
 with st.expander("Monthly totals (kWh/m² per month)", expanded=False):
     st.dataframe(monthly_summary.rename(columns={"POA_kWh_per_m2": "POA kWh/m²"}))
 
-st.caption("Model: Ineichen clear-sky via pvlib; no clouds or real-time weather. For measured/TMY weather, we can plug in EPW/TMY/NSRDB next.")
+st.caption("Model: pvlib Ineichen clear-sky or user-provided CSV irradiance (GHI/DNI/DHI). CSV timestamps are shifted to the selected timezone and present year.")


### PR DESCRIPTION
## Summary
- add utilities to clean uploaded irradiance CSVs, align timestamps to the target timezone/year, and compute daily energy with forward differencing
- extend the sidebar to let users choose between the pvlib clear-sky model and an uploaded CSV with column mapping and preview
- drive the POA pipeline from either source while keeping downstream visuals and KPIs consistent

## Testing
- python -m compileall pv_poa_app.py

------
https://chatgpt.com/codex/tasks/task_e_68d911f620ec8329b088d2cde0cf7889